### PR TITLE
Adding api to add block to ipfs

### DIFF
--- a/shell.go
+++ b/shell.go
@@ -499,3 +499,41 @@ func (s *Shell) BlockStat(path string) (string, int, error) {
 
 	return inf.Key, inf.Size, nil
 }
+
+func (s *Shell) BlockPut(r io.Reader) (string, int, error) {
+	var rc io.ReadCloser
+	if rclose, ok := r.(io.ReadCloser); ok {
+		rc = rclose
+	} else {
+		rc = ioutil.NopCloser(r)
+	}
+
+	// handler expects an array of files
+	fr := files.NewReaderFile("", "", rc, nil)
+	slf := files.NewSliceFile("", "", []files.File{fr})
+	fileReader := files.NewMultiFileReader(slf, true)
+
+	req := NewRequest(s.url, "block/put")
+	req.Body = fileReader
+
+	resp, err := req.Send(s.httpcli)
+	if err != nil {
+		return "", 0, err
+	}
+	defer resp.Close()
+	if resp.Error != nil {
+		return "", 0, resp.Error
+	}
+
+	var inf struct {
+		Key  string
+		Size int
+	}
+
+	err = json.NewDecoder(resp.Output).Decode(&inf)
+	if err != nil {
+		return "", 0, err
+	}
+
+	return inf.Key, inf.Size, nil
+}

--- a/shell.go
+++ b/shell.go
@@ -500,7 +500,7 @@ func (s *Shell) BlockStat(path string) (string, int, error) {
 	return inf.Key, inf.Size, nil
 }
 
-func (s *Shell) BlockPut(r io.Reader) (string, int, error) {
+func (s *Shell) BlockPut(r io.Reader) (string, error) {
 	var rc io.ReadCloser
 	if rclose, ok := r.(io.ReadCloser); ok {
 		rc = rclose
@@ -518,11 +518,11 @@ func (s *Shell) BlockPut(r io.Reader) (string, int, error) {
 
 	resp, err := req.Send(s.httpcli)
 	if err != nil {
-		return "", 0, err
+		return "", err
 	}
 	defer resp.Close()
 	if resp.Error != nil {
-		return "", 0, resp.Error
+		return "", resp.Error
 	}
 
 	var inf struct {
@@ -532,8 +532,8 @@ func (s *Shell) BlockPut(r io.Reader) (string, int, error) {
 
 	err = json.NewDecoder(resp.Output).Decode(&inf)
 	if err != nil {
-		return "", 0, err
+		return "", err
 	}
 
-	return inf.Key, inf.Size, nil
+	return inf.Key, nil
 }

--- a/shell.go
+++ b/shell.go
@@ -500,7 +500,7 @@ func (s *Shell) BlockStat(path string) (string, int, error) {
 	return inf.Key, inf.Size, nil
 }
 
-func (s *Shell) BlockPut(r io.Reader) (string, error) {
+func (s *Shell) PutBlock(r io.Reader) (string, error) {
 	var rc io.ReadCloser
 	if rclose, ok := r.(io.ReadCloser); ok {
 		rc = rclose


### PR DESCRIPTION
uses /block/put api to add block to IPFS. returns hash, size and error.
